### PR TITLE
dump-psql: Remove output for successful operations

### DIFF
--- a/dump-psql
+++ b/dump-psql
@@ -2,4 +2,4 @@
 # must run as geekotest
 
 pg_dump -Fc -c openqa  -f ~/SQL-DUMPS/`date -Idate`.dump
-find ~/SQL-DUMPS/ -mtime +7 -print0 | xargs --no-run-if-empty -0 rm -v
+find ~/SQL-DUMPS/ -mtime +7 -print0 | xargs --no-run-if-empty -0 rm


### PR DESCRIPTION
As we run this script via cron it should only output anything if an error occurs.

Related issue: https://progress.opensuse.org/issues/165030